### PR TITLE
Add Optic Syntax

### DIFF
--- a/docs/overview/using_optics.md
+++ b/docs/overview/using_optics.md
@@ -38,4 +38,14 @@ val io: IO[OpticFailure, Unit] =
   ref.key("key").right.at(0).update(_ + 1)
 ```
 
+You can use this dot syntax with ordinary values using the `optic` operator.
+
+```scala mdoc:compile-only
+val map: Map[String, Either[String, Chunk[Int]]] =
+  ???
+
+val updated: Either[OpticFailure, Map[String, Either[String, Chunk[Int]]]] =
+  map.optic.key("key").right.at(0).update(_ + 1)
+```
+
 Note that this syntax is currently only available for optics defined in ZIO Optics. When automatic derivation of optics is introduced this syntax will be supported for user defined data structures as well.

--- a/src/main/scala/zio/optics/Optics.scala
+++ b/src/main/scala/zio/optics/Optics.scala
@@ -5,4 +5,18 @@ trait Optics
     with OpticFailureModule
     with OpticModule
     with OpticResultModule
-    with OpticTypesModule
+    with OpticTypesModule {
+
+  /**
+   * Provides implicit syntax for working with any value as a partially
+   * applied optic.
+   */
+  implicit final class OpticSyntax[Whole](private val self: Whole) {
+
+    /**
+     * Views this value as a partially applied optic.
+     */
+    def optic: OpticPartiallyApplied[Whole, Nothing, Nothing, Whole, Whole] =
+      Optic.identity(self)
+  }
+}

--- a/src/test/scala/zio/optics/TraversalSpec.scala
+++ b/src/test/scala/zio/optics/TraversalSpec.scala
@@ -4,14 +4,13 @@ import zio._
 import zio.test._
 import zio.test.Assertion._
 
-object TraversalSpec extends DefaultRunnableSpec {
+object TraversalSpec extends DefaultRunnableSpec with EitherCompat {
 
   def spec = suite("TraversalSpec")(
     suite("operators")(
       testM("update") {
         check(Gen.chunkOf(Gen.either(Gen.anyInt, Gen.anyInt)), Gen.function(Gen.anyInt)) { (chunk, f) =>
-          val rights   = Optic.identity[Chunk[Either[Int, Int]]].foreach(Prism.right)
-          val actual   = rights.update(chunk)(_.map(f))
+          val actual   = chunk.optic.foreach(Prism.right).update(_.map(f))
           val expected = chunk.map(_.map(f))
           assert(actual)(isRight(equalTo(expected)))
         }


### PR DESCRIPTION
Supports viewing any value as a partially applied optic. This allows using the dot syntax with ordinary values in addition to values inside ZIO data types